### PR TITLE
GitHub build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-linux:
+    strategy:
+      # Don't abort runners if a single one fails
+      fail-fast: false
+      matrix:
+        ## ubuntu-18.04 does not work because of a gzip decompression issue
+        os: [ubuntu-20.04, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          DEPS=lib32ncurses-dev
+          if [[ "${{ matrix.os }}" = "ubuntu-18.04" ]]; then
+            DEPS=lib32ncurses5-dev
+          fi
+          sudo apt-get install -y build-essential gcc-multilib $DEPS cpio file wget texinfo
+
+      - name: Cache downloaded Lotus 1-2-3 IMG files
+        uses: actions/cache@v3
+        with:
+          key: l123-archive
+          path: |
+            ~/*.IMG
+
+      - name: Cache built binutils files
+        uses: actions/cache@v3
+        with:
+          key: ${{ matrix.os }}-binutils
+          path: |
+            ~/ld
+            ~/objdump
+            ~/objcopy
+
+      - name: Build
+        run: docker/build-from-container.sh


### PR DESCRIPTION
This PR requires #10 and allows an automatic GitHub workflow to build Lotus 1-2-3; both the IMG file downloads and the custom binutils are cached.

Unfortunately I could not make it work for Ubuntu 18.04 as it gives a weird error related to gzip decompression (with multiple files):
```
invalid compressed data--code out of range
```

If someone would like to experiment further it is sufficient to re-add `ubuntu-18.04` to the matrix values.