### PR TITLE
Updated .gitignore to include new ./binutils.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ objdump
 coffsyrup
 123
 ld
+binutils-*


### PR DESCRIPTION
Updated the .gitignore file to include the compiled Binutils made by the ./binutils.sh script, which includes the .tar.gz downloaded and the compiled files