### PR TITLE
adds install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ ASFLAGS = --32
 LDFLAGS = $(CFLAGS) -B. -Wl,-b,coff-i386 -no-pie
 LDLIBS = -lncurses -ltinfo
 PATH := .:$(PATH)
+prefix ?= /
+bindir = ${prefix}usr/local/bin
+sharedir = ${prefix}usr/local/share/lotus
+profiledir = ${prefix}etc/profile.d
 
 define BFD_TARGET_ERROR
 Your version of binutils was compiled without coff-i386 target support.
@@ -51,6 +55,19 @@ dl_init.o: orig/dl_init.o
 
 123: 123.o dl_init.o main.o wrappers.o patch.o | forceplt.o
 	$(CC) forceplt.o $(CFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
+
+install:
+	mkdir -p ${bindir} ${sharedir}/bin
+	cp -r ./root ${sharedir}
+	install -Dm 755 123 ${sharedir}/123
+	install -Dm 755 run.sh ${bindir}/123
+	mkdir -p ${profiledir}
+	echo export LOTUS_HOME="${sharedir}" > ${profiledir}/lotus
+
+uninstall:
+	rm -r ${sharedir}
+	rm ${bindir}/123
+	rm ${profiledir}/lotus
 
 clean:
 	rm -f *.o 123 coffsyrup

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PATH := .:$(PATH)
 prefix ?= /
 bindir ?= ${prefix}usr/local/bin
 sharedir = ${prefix}usr/local/share/lotus
+mandir ?= ${prefix}usr/local/share/man/man1
 profiledir = ${prefix}etc/profile.d
 
 define BFD_TARGET_ERROR
@@ -61,6 +62,7 @@ install:
 	cp -r ./root ${sharedir}
 	install -Dm 755 123 ${sharedir}/123
 	install -Dm 755 run.sh ${bindir}/123
+	install -Dm 644 root/lotus/man/man1/123.1 ${mandir}/123.1
 	mkdir -p ${profiledir}
 	echo export LOTUS_HOME="${sharedir}" > ${profiledir}/lotus.sh
 	chmod +x ${profiledir}/lotus.sh

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS = $(CFLAGS) -B. -Wl,-b,coff-i386 -no-pie
 LDLIBS = -lncurses -ltinfo
 PATH := .:$(PATH)
 prefix ?= /
-bindir = ${prefix}usr/local/bin
+bindir ?= ${prefix}usr/local/bin
 sharedir = ${prefix}usr/local/share/lotus
 profiledir = ${prefix}etc/profile.d
 
@@ -62,7 +62,8 @@ install:
 	install -Dm 755 123 ${sharedir}/123
 	install -Dm 755 run.sh ${bindir}/123
 	mkdir -p ${profiledir}
-	echo export LOTUS_HOME="${sharedir}" > ${profiledir}/lotus
+	echo export LOTUS_HOME="${sharedir}" > ${profiledir}/lotus.sh
+	chmod +x ${profiledir}/lotus.sh
 
 uninstall:
 	rm -r ${sharedir}

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,11 @@ ASFLAGS = --32
 LDFLAGS = $(CFLAGS) -B. -Wl,-b,coff-i386 -no-pie
 LDLIBS = -lncurses -ltinfo
 PATH := .:$(PATH)
-prefix ?= /
-bindir ?= ${prefix}usr/local/bin
-sharedir = ${prefix}usr/local/share/lotus
-mandir ?= ${prefix}usr/local/share/man/man1
+DESTDIR ?= /
+prefix ?= ${DESTDIR}usr/local
+bindir ?= ${prefix}/bin
+sharedir = ${prefix}/share/lotus
+mandir ?= ${prefix}/share/man/man1
 profiledir = ${prefix}etc/profile.d
 
 define BFD_TARGET_ERROR

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ When that's complete, copy `objcopy` and `objdump` from the `binutils` directory
 
 The Makefile should automatically use the new binaries, and continue to build.
 
+## Installing
+
+Run `make install`
+By default it will install to /usr/local
+In case you want to change the base dir run `make prefix=path install`
+In case you want to change the bindir you can append `bindir=path` (e.g. `make bindir=usr`)
+
+It will install:
+ - the shared files of the lotus installation to the shared folder 
+ - The relinked binary
+ - A shim to run Lotus on the bin folder
+
+*Observerd limitation: when checking pathing it seems to access some file in the shared folder which make it appeared as if it stuck when it try to change it*
+
+
 ## Running
 
 Copy the file `l123set.cf` to `~/.l123set`, and run `./123`.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In case you want to change the bindir you can append `bindir=path` (e.g. `make b
 It will install:
  - the shared files of the lotus installation to the shared folder 
  - The relinked binary
- - A shim to run Lotus on the bin folder
+ - A shim to run Lotus on the system bin folder  based on the envrionemnt variable `LOTUS_HOME`
 
 *Observerd limitation: when checking pathing it seems to access some file in the shared folder which make it appeared as if it stuck when it try to change it*
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd ${LOTUS_HOME}
+TERM=xterm ./123 "$@"


### PR DESCRIPTION
adds install target to be system wide
Limitation observed:
 1. lotus try to access some file when launching in the shared folder, it seems to only make the welcome screen stuck but haven't tested further (it also try to change the ownership of those files)
 2. lotus have it's own terminfo library I've changed the launcher shim to overwrite the TERM to xterm since I was using st and lotus didn't have it.