### PR TITLE
Turn off banner/splash screen by default

### DIFF
--- a/main.c
+++ b/main.c
@@ -11,6 +11,7 @@ int main(int argc, char **argv, char **envp)
     putenv("TERMINFO=/usr/share/terminfo/");
     putenv("LOTUS_OS_ENV=x");
     putenv("LOTUS_ESCAPE_TIMEOUT=10");
+    putenv("LOTUS_NO_BANNER=1");
     setenv("TMPDIR", "/tmp", 0);
 
     setchrclass("ascii");

--- a/patch.c
+++ b/patch.c
@@ -67,3 +67,15 @@ int display_column_labels()
                        displayed_window[18] - 1);
     return x_disp_txt_write(displayed_window[21], buf, 0);
 }
+
+extern int print_banner();
+int banner_on()
+{
+    const char *opt = getenv("LOTUS_NO_BANNER");
+    if (opt && !strcmp(opt, "1"))
+        return 0;
+
+    print_banner();
+    sleep(5);
+    return 1;
+}

--- a/undefine.lst
+++ b/undefine.lst
@@ -249,3 +249,4 @@ load_printer_drivers
 close_printer_drivers
 read_print_config_dir
 display_column_labels
+banner_on


### PR DESCRIPTION
The banner on startup did sleep(5) which can be annoying. Environment
variable "LOTUS_NO_BANNER" is introduced an an alternative way to switch.
It is now disabled by default.