### PR TITLE
Enforce UNIX file-name mode

### DIFF
--- a/main.c
+++ b/main.c
@@ -8,11 +8,25 @@ extern int setchrclass(const char *class);
 
 int main(int argc, char **argv, char **envp)
 {
+    char **new_argv;
+
     putenv("TERMINFO=/usr/share/terminfo/");
     putenv("LOTUS_OS_ENV=x");
     putenv("LOTUS_ESCAPE_TIMEOUT=10");
     setenv("TMPDIR", "/tmp", 0);
 
     setchrclass("ascii");
-    return __unix_main(argc, argv, envp);
+
+    // Enforce UNIX file-name mode
+    new_argv = malloc((argc + 3) * sizeof(*new_argv));
+    if (argc > 1) {
+        memcpy(&new_argv[3], &argv[1], (argc - 1) * sizeof(*new_argv));
+    }
+    new_argv[0] = argv[0];
+    new_argv[1] = "-f";
+    new_argv[2] = "unix";
+    argc += 2;
+    new_argv[argc] = NULL;
+
+    return __unix_main(argc, new_argv, envp);
 }


### PR DESCRIPTION
For default configurations, Lotus 1-2-3 for UNIX set DOS file-name mode,
which can be unfriendly to native Linux port. It defaults to UNIX
file-name mode instead.