### PR TITLE
Fix segfault with option "-b"

### DIFF
--- a/main.c
+++ b/main.c
@@ -15,7 +15,7 @@ extern int setchrclass(const char *class);
 
 static void hide_option_from_lotus(int *argc, char **argv) {
     // We can't remove options like -xyz or -zparam.
-    if (argv[optind][0] != '-' || argv[optind][2] != '\0') {
+    if (argv[optind] && (argv[optind][0] != '-' || argv[optind][2] != '\0')) {
         errx(EXIT_FAILURE, "Options cannot be combined.");
     }
 


### PR DESCRIPTION
GDB Traces:

Program received signal SIGSEGV, Segmentation fault.
hide_option_from_lotus (argc=0xffffd2a0, argv=0xffffd334) at main.c:18
warning: Source file is more recent than executable.
18	    if (argv[optind][0] != '-' || argv[optind][2] != '\0') {
(gdb) p optind
$1 = 2
(gdb) p argv[optind]
$2 = 0x0