### PR TITLE
Re-implement shell functionality

### DIFF
--- a/undefine.lst
+++ b/undefine.lst
@@ -266,3 +266,4 @@ floor
 ceil
 fmod
 fabs
+shell


### PR DESCRIPTION
"/System" is supposed to redirect to a command shell, useful for macros.
However, the terminal would mess up. Symbol "symbol" is now overridden
by the combination of termio and posix_spawn, which respect the original
terminal configurations.

Close #15