### PR TITLE
Use functions provided by libm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS  = -lc -m32 -ggdb3 -O0 -fno-stack-protector
 CPPFLAGS = -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64 -D_GNU_SOURCE -I ttydraw
 ASFLAGS = --32
 LDFLAGS = $(CFLAGS) -B. -Wl,-b,coff-i386 -no-pie
-LDLIBS = -lncurses -ltinfo
+LDLIBS = -lncurses -ltinfo -lm
 PATH := .:$(PATH)
 
 define BFD_TARGET_ERROR

--- a/forceplt.s
+++ b/forceplt.s
@@ -229,3 +229,17 @@ __require_ref:
     call    fstat64@plt
     call    stat64@plt
     call    atexit@plt
+    call    sin@plt
+    call    cos@plt
+    call    tan@plt
+    call    atan2@plt
+    call    asin@plt
+    call    acos@plt
+    call    remainder@plt
+    call    sqrt@plt
+    call    log@plt
+    call    log10@plt
+    call    floor@plt
+    call    ceil@plt
+    call    fmod@plt
+    call    fabs@plt

--- a/redefine.lst
+++ b/redefine.lst
@@ -26,3 +26,13 @@ readdir __unix_readdir
 memcpy memmove
 # Difficult symbol names.
 banner_printed.0 banner_printed
+# 1-2-3 provides its own math functions. However, modern libm outperforms them.
+# Let's map them to libm counterparts.
+ksin sin
+kcos cos
+ktan tan
+katan2 atan2
+kasin asin
+kacos acos
+# drem is obsolete.
+drem remainder

--- a/undefine.lst
+++ b/undefine.lst
@@ -252,3 +252,17 @@ read_print_config_dir
 display_column_labels
 init_unix_display_code
 at_date
+sin
+cos
+tan
+tan2
+asin
+acos
+remainder
+sqrt
+log
+log10
+floor
+ceil
+fmod
+fabs


### PR DESCRIPTION
Lotus 1-2-3 provides its own math functions along with statically
linked math routines. However, modern libm should outperform them.
Let's map them to libm counterparts. Hopefully, it will result in
a slightly faster and smaller executable.