### PR TITLE
Build the essential binutils componenents rather than everything

### DIFF
--- a/binutils.sh
+++ b/binutils.sh
@@ -37,8 +37,13 @@ fi
 # Compile binutils.
 if [ ! -x "$BINUTILS_DIR/binutils/objcopy" ]; then
    cd "$BINUTILS_DIR"
-   ./configure --enable-targets=all
-   make -j$(nproc) MAKEINFO=true
+   ./configure --enable-targets=all \
+               --enable-ld=default \
+               --disable-plugins \
+               --disable-werror --disable-nls \
+               --disable-gas --disable-libctf --disable-gprof \
+               --with-system-zlib
+   make all-ld -j$(nproc) MAKEINFO=true
 fi
 
 # Copy compiled binaries to working directory.


### PR DESCRIPTION
Although we have to enable all targets for i386-coff, there is still
room for the improvements of binutils build. We can disable the
components which are not associated with the essential one.

Test on AMD Ryzen Threadripper 2990WX 32-Core Processor:
(command: time ./binutils.sh >/dev/null )

[orig]
real    1m15.484s
user    17m12.006s
sys     5m15.846s

[new]
real    1m5.867s
user    15m43.655s
sys     4m55.558s