### PR TITLE
Search for runtime files in shared directory, to support system-wide installation

### DIFF
--- a/extract.sh
+++ b/extract.sh
@@ -62,3 +62,6 @@ fi
 
 echo "==> Copying the banner template over"
 cp -v "${ROOT}/usr/tmp/lotus_install/123/banner" "${LOTUS}/ri/USA-English/123ban.ri"
+
+echo "==> Copying default configuration file"
+cp -v "${BASE}/l123set.cf" "${ROOT}/lotus/l123set.cf"

--- a/filemap.c
+++ b/filemap.c
@@ -9,17 +9,34 @@
 // Figure out where our runtime files are located.
 static const char *get_lotus_runtimefile(const char *file)
 {
-    static char procpath[PATH_MAX];
-    static char filepath[PATH_MAX];
     static char *lotusdir;
+    static char exepath[PATH_MAX];
+    static char *exedir;
+    static char filepath[PATH_MAX];
+    static char localcheck[PATH_MAX];
+    static char localpath[PATH_MAX];
+    static char sharecheck[PATH_MAX];
+    static char sharepath[PATH_MAX];
 
     // Cache this path so it only has to be looked up once.
     if (lotusdir == NULL) {
-        if (readlink("/proc/self/exe", procpath, PATH_MAX) == -1) {
+        if (readlink("/proc/self/exe", exepath, PATH_MAX) == -1) {
             err(EXIT_FAILURE, "Failed to determine the lotus root directory");
         }
         // Figure out the containing directory from the exe path.
-        lotusdir = dirname(procpath);
+        exedir = dirname(exepath);
+        snprintf(localpath, PATH_MAX, "%s/%s", exedir, "root/lotus");
+        lotusdir = localpath;
+        // If runtime files can not be found in the directory that contains the exe,
+        // try to find them installed under ../share/lotus
+        snprintf(localcheck, PATH_MAX, "%s/%s", exedir, "root/lotus/123.v10");
+        if (access(localcheck, F_OK) != 0) {
+            snprintf(sharecheck, PATH_MAX, "%s/%s", exedir, "../share/lotus/123.v10");
+            if (access(sharecheck, F_OK) == 0) {
+                snprintf(sharepath, PATH_MAX, "%s/%s", exedir, "../share/lotus");
+                lotusdir = sharepath;
+            }
+        }
     }
 
     // Append the requested filename, obviously this is not reentrant, but 123

--- a/l123set.cf
+++ b/l123set.cf
@@ -1,5 +1,5 @@
 1001 Lotus 1-2-3 Version "10"
-1002 Base Directory "/{LOTUSROOT}/root/lotus"
+1002 Base Directory "/{LOTUSROOT}"
 1003 Printer Interface "lpr -o dest={dest} {file}"
 1004 Graphics Driver "dumb" "ega egas25cc.vbd"
 1007 Help Language "USA English" "USA-English"


### PR DESCRIPTION
Check directories relative to the directory the executable is run from.

If runtime files dir is not found under `${exedir}/root/lotus`, try searching in `${exedir}/../share/lotus`.

This should help support system-wide installation and packaging.

Related to issue #66 