### PR TITLE
Do not initialize termios struct with {0}

### DIFF
--- a/wrappers.c
+++ b/wrappers.c
@@ -45,7 +45,7 @@ void __attribute__((destructor)) fini_terminal_settings()
 int __unix_ioctl(int fd, unsigned long request, struct unixtermios *argp)
 {
     int action;
-    struct termios tio = {0};
+    struct termios tio;
 
     if (argp == NULL) {
         return -1;


### PR DESCRIPTION
It is filled later on with tcgetattr() call and current initialization
causes a segmentation fault with some compilers at -O2 (tested with gcc
12.1.1 20220625 and clang 14.0.6, -O0 or gcc 11 work fine)

Backtrace with -O2 -ggdb3:

Program received signal SIGSEGV, Segmentation fault.
0x0812eebf in __unix_ioctl (fd=1, request=30211, argp=0x813f33a) at wrappers.c:48
48	    struct termios tio = {0};
(gdb) bt
#0  0x0812eebf in __unix_ioctl (fd=1, request=30211, argp=0x813f33a) at wrappers.c:48
#1  0x08099719 in V3_vt_switch_open ()
#2  0x0811219a in __unix_main ()
#3  0x0812ed30 in main (argc=1, argv=0xffffd034, envp=0xffffd03c) at main.c:226