### PR TITLE
Reimplementation of function at 0x80bb148 that prevents overflowing the destination buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ orig/123.o:
 	@false
 
 123.o: orig/123.o $(OBJCOPY_FILES) | coffsyrup
-	objcopy -I $(BFD_INP_TARGET) -O $(BFD_OUT_TARGET) $(OBJCOPY_FLAGS) $< $@
+	objcopy -I $(BFD_INP_TARGET) -O $(BFD_OUT_TARGET) $(OBJCOPY_FLAGS) --add-symbol FUN_080bb148=.text:0x6e530,function,local $< $@
 	coffsyrup $@ $(@:.o=.tmp.o) $$(cat undefine.lst)
 	mv $(@:.o=.tmp.o) $@
 

--- a/lotdefs.h
+++ b/lotdefs.h
@@ -226,5 +226,6 @@ extern int16_t get_row_label(int16_t row, char *buf);
 extern void display_scan_row(struct CELLCOORD start, int16_t numcols);
 extern int win_column_width(uint16_t, int16_t);
 extern void tty_disp_info(struct DISPLAYINFO *dpyinfo);
+extern void memdup(void *, uint32_t, uint32_t);
 
 #endif

--- a/patch.c
+++ b/patch.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <alloca.h>
 #include <curses.h>
+#include <string.h>
 
 #include "lottypes.h"
 #include "lotdefs.h"
@@ -76,4 +77,40 @@ int set_raw_mode()
 int unset_raw_mode()
 {
     return 0;
+}
+
+uint32_t FUN_080bb148(uint32_t *dst, uint32_t *src, uint16_t src_len)
+{
+    void *retaddr =  __builtin_extract_return_addr(__builtin_return_address(0));
+
+    // determine the right buffer size based on the function that called us
+    uint32_t dst_len = 0;
+    if (memcmp(retaddr,"\x66\x89\x85\xec\xfb\xff\xff",7) == 0) { // MOV word ptr [EBP + local_418],AX (process_fmt())
+        dst_len = 1024;
+    } else if (memcmp(retaddr,"\x83\xc4\x0c",3) == 0) { // ADD ESP, 0xc (fmt_cell_combine())
+        dst_len = 256;
+    }
+
+    uint32_t *dptr, *dst_end = dst + dst_len/4;
+
+    for (dptr = dst; src_len >= 4 && dptr < dst_end; dptr++) {
+        *dptr = *src++;
+        src_len -= 4;
+        if (*dptr > 0x80000000) {
+            *dptr &= 0x7fffffff;
+            if (src_len != 0) {
+                uint8_t *sptr = (uint8_t *)src;
+                uint8_t reps = *sptr;
+                if (dptr + reps + 1 >= dst_end) {
+                    // prevent overflow
+                    break;
+                }
+                memdup(dptr, 4, reps*4 + 4);
+                src_len -= 1;
+                dptr += reps;
+                src = (uint32_t *)(sptr+1);
+            }
+        }
+    }
+    return dptr - dst;
 }

--- a/undefine.lst
+++ b/undefine.lst
@@ -292,3 +292,4 @@ setup_invalid_columns
 invalidate_cell_cols
 find_invalid_column
 tty_disp_info
+FUN_080bb148


### PR DESCRIPTION
Fixes #103 

This replaces the vulnerable function with a version that aborts the copy if the destination buffer is full.

Adding destination length checks within `process_fmt()`/`fmt_cell_combine()` isn't enough, because the vulnerable function can apply a form of run-length decoding based on the values in the source buffer (using `memdup()`).  This can cause the destination buffer to expand beyond the size of the source buffer.  The proof-of-concept exploit does this to overflow a 1024-byte buffer with a 38-byte file.

Replacing a function without a symbol was a bit tricky (and I'm not sure if this is the best way to handle it) but it seems to work and all of the tests pass.  I won't be offended if you decide to go with an entirely different approach!