### PR TITLE
Fix buffer overflows

### DIFF
--- a/coffsyrup.c
+++ b/coffsyrup.c
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
                 errx(EXIT_FAILURE, "Unsupported relocation type %u", rel->r_type);
             }
 
-            if (rel->r_symndx > hdr.f_nsyms) {
+            if (rel->r_symndx >= hdr.f_nsyms) {
                 errx(EXIT_FAILURE, "A relocation references a non-existent symbol %u.", rel->r_symndx);
             }
 
@@ -282,7 +282,7 @@ int main(int argc, char **argv)
                         ? strndupa(symtab[rel->r_symndx].e.e_name, sizeof symtab[rel->r_symndx].e.e_name)
                         : (strtab + symtab[rel->r_symndx].e.e.e_offset);
 
-            if (rel->r_vaddr < scn[i].s_vaddr || rel->r_vaddr > scn[i].s_vaddr + scn[i].s_size) {
+            if (rel->r_vaddr < scn[i].s_vaddr || rel->r_vaddr + sizeof(uint32_t) > scn[i].s_vaddr + scn[i].s_size) {
                 warn("Relocation %#x -> %s appears to be out of range (%#x-%#x).",
                      rel->r_vaddr,
                      symname,

--- a/main.c
+++ b/main.c
@@ -161,26 +161,19 @@ int main(int argc, char **argv, char **envp)
     // Configure our @functions here.
     init_at_funcs();
 
-    // We always need at least two entries, for argv[0] and a terminator.
+    // Count the maximum number of lotargv entries needed.
+    // Each getopt iteration can produce up to 2 entries (flag + optarg).
     lotargc = 2;
 
-    // We need to do a first pass through the options to see how many there
-    // are.
     while ((opt = getopt(argc, argv, optstring)) != -1)
-        lotargc++;
+        lotargc += 2;
 
-    // If there was a non-option parameter, we will inject a synthetic
-    // parameter.
     if (argv[optind] != NULL)
         lotargc += 2;
 
-    // Allocate the argument vector we're going to pass through to lotus.
     lotargv = alloca(lotargc * sizeof(*argv));
 
-    // Now reset and copy the options over.
     lotargc = 0;
-
-    // Reset optind to restart getopt();
     optind = 1;
 
     // The first argument is the same.

--- a/src/display.c
+++ b/src/display.c
@@ -29,7 +29,7 @@ static inline bool compare_cell(struct CELLCOORD a, struct CELLCOORD b)
 
 int mr_step_wait()
 {
-    char stpstatus[64];
+    char stpstatus[256];
     uint32_t key  = input_key();
     uint16_t wkey = key;
     char *p;
@@ -52,19 +52,17 @@ int mr_step_wait()
     // If possible, give a snippet of the macro.
     if (cmdhandle) {
         char *cmdname = access_resource(cmdhandle);
-        strcat(stpstatus, ": {");
-        strcat(stpstatus, cmdname);
-        strcat(stpstatus, "}");
+        size_t prefix_len = strlen(stpstatus);
+        size_t remain = sizeof(stpstatus) - prefix_len;
 
         if (mac_str) {
-            strcat(stpstatus, " (");
-            strncat(stpstatus, mac_str, 16);
-
-            // If the string is very long, truncate it.
-            if (strlen(mac_str) > 16)
-                strcat(stpstatus, "...");
-
-            strcat(stpstatus, ")");
+            snprintf(stpstatus + prefix_len, remain,
+                     ": {%s} (%.16s%s)",
+                     cmdname, mac_str,
+                     strlen(mac_str) > 16 ? "..." : "");
+        } else {
+            snprintf(stpstatus + prefix_len, remain,
+                     ": {%s}", cmdname);
         }
     }
 

--- a/src/showme.c
+++ b/src/showme.c
@@ -82,6 +82,8 @@ void clear_showme(int16_t sheet, int16_t row, int16_t numrows)
 {
     do {
         if (find_row(sheet, row) == &showme_data.rowdata) {
+            if (showme_data.count >= MAX_SHOWME)
+                break;
             showme_data.rowindex[showme_data.count] = row;
             showme_data.sheetindex[showme_data.count] = sheet;
             memset(&showme_data.rows[showme_data.count], 0, sizeof(SHOWMEROW));


### PR DESCRIPTION
- display.c: stpstatus[64] overflow via strcat chain; enlarged to 256, replaced with bounded snprintf
- main.c: lotargv alloca undercount; first-pass counted 1 per option but pass-through options with args need 2 slots; count += 2 per iteration
- showme.c: clear_showme writes past MAX_SHOWME arrays; add count guard
- coffsyrup.c: Relocation boundary check allows 4-byte write past section buffer; account for sizeof(uint32_t) in range check Symbol index off-by-one; change > to >= for f_nsyms bound