### PR TITLE
Fix unsafe realloc

### DIFF
--- a/coffsyrup.c
+++ b/coffsyrup.c
@@ -188,7 +188,12 @@ int main(int argc, char **argv)
                         errx(EXIT_FAILURE, "The static symbol %s did not have a section number.", symname);
                     }
 
-                    pmkrelocs = realloc(pmkrelocs, ++nmkrelocs * sizeof(*pmkrelocs));
+                    void *tmp = realloc(pmkrelocs, (nmkrelocs + 1) * sizeof(*pmkrelocs));
+                    if (!tmp) {
+                        err(EXIT_FAILURE, "Failed to allocate relocation entry");
+                    }
+                    pmkrelocs = tmp;
+                    nmkrelocs++;
                     pmkrelocs[nmkrelocs - 1].e_value = symtab[i].e_value;
                     pmkrelocs[nmkrelocs - 1].r_symndx = i;
 


### PR DESCRIPTION
realloc() result was assigned directly to pmkrelocs, leaking the old allocation and dereferencing NULL on failure. Use a temporary pointer with an error check before assignment.